### PR TITLE
Portable build

### DIFF
--- a/.github/workflows/CI-ci-remote.yml
+++ b/.github/workflows/CI-ci-remote.yml
@@ -8,7 +8,10 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: 
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 1"  # Runs every Monday at 5:00 UTC
+
 
 env:
   RUST_BACKTRACE: 1
@@ -51,3 +54,19 @@ jobs:
           toolchain: nightly
           command: make
           args: udeps
+
+  build-test-mac:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Run Tests
+        uses: actions-rs/cargo@v1
+        with:
+          toolchain: stable
+          command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ultraplonk_verifier"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A Rust library to verify ultraplonk proof. This library is a wrapping for C++ barretenberg library."
 repository = "https://github.com/HorizenLabs/ultraplonk_verifier"
@@ -28,6 +28,7 @@ serial_test = "3.1.1"
 bindgen = "0.69"
 cc = "1.0"
 cmake = "0.1"
+regex = { version = "1" }
 
 [[bin]]
 name = "noir-cli"
@@ -35,4 +36,11 @@ path = "src/bin/noir_cli/main.rs"
 required-features = ["bins"]
 
 [features]
-bins = ["dep:clap", "dep:hex", "dep:anyhow", "dep:regex", "dep:serde_json", "dep:serde"]
+bins = [
+    "dep:clap",
+    "dep:hex",
+    "dep:anyhow",
+    "dep:regex",
+    "dep:serde_json",
+    "dep:serde",
+]

--- a/patches/barretenberg_001.patch
+++ b/patches/barretenberg_001.patch
@@ -1,0 +1,12 @@
+diff --git a/cpp/src/barretenberg/common/zip_view.hpp b/cpp/src/barretenberg/common/zip_view.hpp
+index 964888ac6..c94ce5db9 100644
+--- a/cpp/src/barretenberg/common/zip_view.hpp
++++ b/cpp/src/barretenberg/common/zip_view.hpp
+@@ -76,6 +76,7 @@ static_assert(__cplusplus >= 201703L,
+               " must be c++17 or greater"); // could be rewritten in c++11, but the features you must use will be buggy
+                                             // in an older compiler anyways.
+ #include "barretenberg/common/assert.hpp"
++#include <algorithm>
+ #include <cassert>
+ #include <functional>
+ #include <iostream>

--- a/src/key.rs
+++ b/src/key.rs
@@ -417,9 +417,8 @@ fn read_commitment(
     }
 
     let key = String::from_utf8(data[*offset..*offset + key_size].to_vec())
-        .map(|s| {
+        .inspect(|_| {
             *offset += key_size;
-            s
         })
         .map_err(|_| VerificationKeyError::InvalidCommitmentKey { offset: *offset })?;
 
@@ -433,9 +432,8 @@ fn read_commitment(
         });
     }
 
-    read_g1(&field, &data[*offset..*offset + 64]).map(|g1| {
+    read_g1(&field, &data[*offset..*offset + 64]).inspect(|_| {
         *offset += 64;
-        g1
     })
 }
 


### PR DESCRIPTION
- Compile in a portable (use plain arch instead of native)
- Introduce a patch framework
- Patch barretenberg to fix the compile issue on new gcc
- Change the link order: the previous one fails to compile test in the recent rust version
- Add a scheduled ci execution every week
- Run ci also on Mac